### PR TITLE
Skip check for branches are different of default

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -23,11 +23,12 @@ jobs:
           docs_url: "https://olxbr.atlassian.net/l/cp/vQZeDHDM"
   
   skip-quality-gate-for-non-default-branch:
+    if: github.base_ref != github.event.repository.default_branch
     name: Skip Quality Gate (Non default branch)
     runs-on: ubuntu-latest
     steps:
       - shell: bash
         run: |
-          ## PR DIFFERENT OF DEFAUL BRANCH
+          ## PR DIFFERENT OF DEFAULT BRANCH
           echo "Skipped"
   

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -21,3 +21,13 @@ jobs:
           unit_test_check_timeout: ${{ vars.UNIT_TEST_CHECK_TIMEOUT }}
           gates_to_skip: ${{ vars.GATES_TO_SKIP }}
           docs_url: "https://olxbr.atlassian.net/l/cp/vQZeDHDM"
+  
+  skip-quality-gate-for-non-default-branch:
+    name: Skip Quality Gate (Non default branch)
+    runs-on: ubuntu-latest
+    steps:
+      - shell: bash
+        run: |
+          ## PR DIFFERENT OF DEFAUL BRANCH
+          echo "Skipped"
+  


### PR DESCRIPTION
Required workflow must be executed on each PR. For PR that is not in default branch, need to executed and return true