### PR TITLE
Hide gh exporter endpoint

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -21,6 +21,7 @@ jobs:
           unit_test_check_timeout: ${{ vars.UNIT_TEST_CHECK_TIMEOUT }}
           gates_to_skip: ${{ vars.GATES_TO_SKIP }}
           docs_url: "https://olxbr.atlassian.net/l/cp/vQZeDHDM"
+          gh_metrics_server_endpoint: ${{ secrets.GH_METRICS_SERVER_ENDPOINT }}
   
   skip-quality-gate-for-non-default-branch:
     if: github.base_ref != github.event.repository.default_branch


### PR DESCRIPTION
Add new secret for gh metrics server. Useful to hide the endpoint